### PR TITLE
fix: correct StatCan API request format

### DIFF
--- a/app.js
+++ b/app.js
@@ -354,14 +354,14 @@ class StatCanExplorer {
 
         // Format request data according to Statistics Canada API specification
         // API expects: [{"vectorId":32164132, "latestN":3}]
-        const requestData = Array.from(this.selectedVectors.keys()).map(vectorId => {
-            // Remove 'v' prefix if present and convert to integer
-            const numericId = vectorId.startsWith('v') ? parseInt(vectorId.substring(1)) : parseInt(vectorId);
-            return {
-                vectorId: numericId,
-                latestN: periods
-            };
-        });
+        // Statistics Canada API expects an object with an array of vectorIds and a single latestN value
+        const requestData = {
+            vectorIds: Array.from(this.selectedVectors.keys()).map(vectorId => {
+                // Remove 'v' prefix if present and convert to integer
+                return vectorId.startsWith('v') ? parseInt(vectorId.substring(1)) : parseInt(vectorId);
+            }),
+            latestN: periods
+        };
 
         try {
             console.log('Attempting to fetch data for vectors:', requestData);


### PR DESCRIPTION
## Summary
- send `vectorIds` array with single `latestN` value when requesting data

## Testing
- `node --check app.js`
- `node --check netlify/functions/getDataFromVectors.js`
- `node -e "const {handler}=require('./netlify/functions/getDataFromVectors.js'); handler({httpMethod:'POST', body: JSON.stringify({vectorIds:[86822802], latestN:3})}).then(r=>console.log(r.statusCode, r.body.slice(0,200))).catch(e=>console.error(e));"` *(fails: connect ENETUNREACH 167.44.105.20:443)*

------
https://chatgpt.com/codex/tasks/task_e_68954cefed00832399a195f4b167f0db